### PR TITLE
feat(terraform): add initial AWS webserver infrastructure

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,161 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-south-1"
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "web-vpc"
+  }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "ap-south-1a"
+
+  tags = {
+    Name = "web-public-subnet"
+  }
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "web-igw"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = {
+    Name = "web-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public_assoc" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_security_group" "allow_web" {
+  name        = "allow_web_traffic"
+  description = "Allow HTTP, HTTPS, SSH"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "All egress"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "allow_web"
+  }
+}
+
+resource "aws_network_interface" "web_eni" {
+  subnet_id       = aws_subnet.public.id
+  private_ips     = ["10.0.1.50"]
+  security_groups = [aws_security_group.allow_web.id]
+
+  tags = {
+    Name = "web-eni"
+  }
+}
+
+resource "aws_eip" "web_eip" {
+  domain                    = "vpc"
+  network_interface         = aws_network_interface.web_eni.id
+  associate_with_private_ip = "10.0.1.50"
+  depends_on                = [aws_internet_gateway.igw]
+
+  tags = {
+    Name = "web-eip"
+  }
+}
+
+resource "aws_instance" "web" {
+  ami               = "ami-02d26659fd82cf299"
+  instance_type     = "t2.micro"
+  availability_zone = "ap-south-1a"
+  key_name          = "my-key"
+
+  network_interface {
+    device_index         = 0
+    network_interface_id = aws_network_interface.web_eni.id
+  }
+
+  user_data = <<-EOF
+              #!/bin/bash
+              apt-get update -y
+              DEBIAN_FRONTEND=noninteractive apt-get install -y apache2
+              systemctl enable apache2
+              systemctl start apache2
+              cat >/var/www/html/index.html <<'EOPAGE'
+              <!doctype html>
+              <html lang="en">
+              <head><meta charset="utf-8"><title>AWS Web Server</title></head>
+              <body style="font-family: sans-serif; padding: 2rem;">
+                <h1>Hello from Apache on EC2</h1>
+                <p>Deployed via Terraform + ENI + EIP in a public subnet.</p>
+              </body>
+              </html>
+              EOPAGE
+              EOF
+
+  tags = {
+    Name = "apache-web-server"
+  }
+
+  depends_on = [aws_eip.web_eip]
+}
+
+output "http_url" {
+  value       = "http://${aws_eip.web_eip.public_ip}:80"
+  description = "Convenient HTTP URL"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,18 @@
+data "aws_ami" "ubuntu_2404" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd*/ubuntu-noble-24.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
 resource "aws_vpc" "main" {
   cidr_block = var.vpc_cidr
 
@@ -107,7 +122,7 @@ resource "aws_eip" "web_eip" {
 }
 
 resource "aws_instance" "web" {
-  ami               = "ami-02d26659fd82cf299"
+  ami               = data.aws_ami.ubuntu_2404.id
   instance_type     = "t2.micro"
   availability_zone = var.availability_zone
   key_name          = var.key_name

--- a/main.tf
+++ b/main.tf
@@ -1,56 +1,6 @@
-terraform {
-  required_version = ">= 1.5.0"
-
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
-    }
-  }
-}
-
-variable "aws_region" {
-  type        = string
-  description = "AWS region to deploy into"
-  default     = "ap-south-1"
-}
-
-variable "vpc_cidr" {
-  type        = string
-  description = "CIDR for the VPC"
-  default     = "10.0.0.0/16"
-}
-
-variable "public_subnet_cidr" {
-  type        = string
-  description = "CIDR for the public subnet (must be inside vpc_cidr)"
-  default     = "10.0.1.0/24"
-}
-
-variable "availability_zone" {
-  type        = string
-  description = "AZ for the subnet/instance"
-  default     = "ap-south-1a"
-}
-
-variable "key_name" {
-  type        = string
-  description = "Existing EC2 key pair name"
-  default     = "main_key"
-}
-
-variable "static_private_ip" {
-  type        = string
-  description = "Static private IP for the ENI"
-  default     = "10.0.1.50"
-}
-
-provider "aws" {
-  region = var.aws_region
-}
-
 resource "aws_vpc" "main" {
   cidr_block = var.vpc_cidr
+
   tags = {
     Name = "web-vpc"
   }
@@ -76,6 +26,7 @@ resource "aws_internet_gateway" "igw" {
 
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.main.id
+
   route {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_internet_gateway.igw.id
@@ -189,9 +140,4 @@ resource "aws_instance" "web" {
   }
 
   depends_on = [aws_eip.web_eip]
-}
-
-output "http_url" {
-  value       = "http://${aws_eip.web_eip.public_ip}:80"
-  description = "Convenient HTTP URL"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "http_url" {
+  value       = "http://${aws_eip.web_eip.public_ip}:80"
+  description = "Convenient HTTP URL"
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,36 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region to deploy into"
+  default     = "ap-south-1"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR for the VPC"
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidr" {
+  type        = string
+  description = "CIDR for the public subnet (must be inside vpc_cidr)"
+  default     = "10.0.1.0/24"
+}
+
+variable "availability_zone" {
+  type        = string
+  description = "AZ for the subnet/instance"
+  default     = "ap-south-1a"
+}
+
+variable "key_name" {
+  type        = string
+  description = "Existing EC2 key pair name"
+  default     = "main_key"
+}
+
+# Must be inside the public_subnet_cidr and not a reserved IP
+variable "static_private_ip" {
+  type        = string
+  description = "Static private IP for the ENI"
+  default     = "10.0.1.50"
+}


### PR DESCRIPTION
### Summary
This PR introduces the initial AWS infrastructure setup using Terraform.

### Changes
- Added `main.tf` with VPC, subnet, internet gateway, route table, security group, ENI, Elastic IP, and EC2 instance.
- Added `variables.tf` for configurable inputs.
- Added `providers.tf` to configure AWS provider.
- Added `outputs.tf` for exposing EC2 public webserver URL.

### Why
- Establishes the baseline infrastructure for a public-facing webserver.
- Provides modular Terraform structure for easier maintenance and scalability.
- Prepares the repo for GitHub Actions–based CI/CD pipelines.

### Notes
- Apache webserver is provisioned via `user_data` script.
- Future PRs will add GitHub Actions workflows for CI/CD automation.